### PR TITLE
fix :bug: Reseteo de variable de ciudad tras entrada inválida

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -106,6 +106,7 @@ public class Main {
       if (jsonArray.isEmpty()) {
         System.err.println("No se encontró información con el nombre de ciudad introducido: " + cityName);
         opt = 0;
+        cityName = "";
         continue;
       }
 


### PR DESCRIPTION
Antes, cuando se ingresaba un nombre de ciudad inválido, la variable que contenía el nombre de la ciudad no se reiniciaba, lo que impedía que los usuarios ingresaran un nuevo nombre de ciudad. Este commit soluciona ese problema al asegurarse de que la variable de nombre de la ciudad se reinicie correctamente después de una entrada inválida, permitiendo a los usuarios volver a ingresar un nombre de ciudad válido sin problemas.